### PR TITLE
Fix: 카카오 로그인 실패 시 회원 가입 연동 로직 수정

### DIFF
--- a/src/app/(auth)/oauth/kakao/page.tsx
+++ b/src/app/(auth)/oauth/kakao/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { KAKAO_SIGNUP_OAUTH_URL } from '@/constants/oauth';
 import { oauthSignin } from '@/fetches/oauthSignin';
 import { useUserStore } from '@/stores/useUserStore';
 import { LoginReturn } from '@/types/auth';
@@ -29,7 +30,7 @@ export default function RedirectKakao() {
         router.replace('/');
       } catch (error) {
         if (error instanceof AxiosError && error.status === 403) {
-          router.replace(`/oauth/kakao/signup/${code}`);
+          router.replace(KAKAO_SIGNUP_OAUTH_URL);
         }
       }
     };

--- a/src/app/(auth)/oauth/kakao/signup/page.tsx
+++ b/src/app/(auth)/oauth/kakao/signup/page.tsx
@@ -5,14 +5,23 @@ import { oauthSignup } from '@/fetches/oauthSignup';
 import { useUserStore } from '@/stores/useUserStore';
 import { LoginReturn } from '@/types/auth';
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
-export default function KakaoSignup({ params }: { params: { token: string } }) {
+export default function KakaoSignup() {
   const router = useRouter();
   const { setUser } = useUserStore();
-  const { token } = params;
+  const [code, setCode] = useState('');
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const responseCode = searchParams.get('code');
+    if (responseCode) {
+      setCode(responseCode);
+    }
+  }, []);
 
   const handleKakaoSignupNicknameSubmit = async (nickname: string) => {
-    const data = await oauthSignup({ provider: 'kakao', nickname, code: token });
+    const data = await oauthSignup({ provider: 'kakao', nickname, code });
     const { user, accessToken, refreshToken } = data as LoginReturn;
     setUser({ user, accessToken, refreshToken });
 

--- a/src/app/components/@shared/header/LoggedInContainer.tsx
+++ b/src/app/components/@shared/header/LoggedInContainer.tsx
@@ -2,6 +2,10 @@ import Image from 'next/image';
 import S from './LoggedInContainer.module.scss';
 import defaultProfileImg from '@/images/profiles/default-profile.svg';
 import notificationIcon from '@/images/icons/Icon-notification.svg';
+import useDropdown from '@/hooks/useDropdown';
+import Dropdown from '../dropdown/Dropdown';
+import { useRouter } from 'next/navigation';
+import { useUserStore } from '@/stores/useUserStore';
 
 interface LoggedInContainerProps {
   profileImageUrl: string | null;
@@ -9,17 +13,42 @@ interface LoggedInContainerProps {
   logout: () => void;
 }
 
+const dropdownList = ['마이 페이지', '로그아웃'];
+
 export default function LoggedInContainer({ profileImageUrl, nickname }: LoggedInContainerProps) {
+  const { logout } = useUserStore();
+  const { data, isDropdownToggle, toggleDropdown } = useDropdown(dropdownList);
+  const router = useRouter();
+
+  const handleDropdownChange = (value: string) => {
+    switch (value) {
+      case '마이 페이지':
+        router.push('/mypage');
+        break;
+      case '로그아웃':
+        logout();
+        router.push('/');
+        break;
+    }
+  };
+
   return (
     <div className={S.loggedInContainer}>
       <button className={S.notification}>
         <Image src={notificationIcon} alt="프로필 이미지" width={20} height={20} />
       </button>
       <article className={S.verticalSeparator} />
-      <div className={S.profileContainer}>
+      <div className={S.profileContainer} onClick={toggleDropdown}>
         <Image src={profileImageUrl || defaultProfileImg} alt="프로필 이미지" width={32} height={32} priority />
         <p className={S.nickname}>{nickname}</p>
       </div>
+      <Dropdown
+        type="hide"
+        data={data}
+        onChange={value => handleDropdownChange(value)}
+        isDropdownToggle={isDropdownToggle}
+        toggleDropdown={toggleDropdown}
+      />
     </div>
   );
 }

--- a/src/constants/oauth.ts
+++ b/src/constants/oauth.ts
@@ -1,2 +1,3 @@
 export const KAKAO_OAUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}&response_type=code`;
+export const KAKAO_SIGNUP_OAUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_SIGNUP_REDIRECT_URI}&response_type=code`;
 export const GOOGLE_OAUTH_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI}&response_type=code&scope=email profile openid`;

--- a/src/fetches/oauthSignup.ts
+++ b/src/fetches/oauthSignup.ts
@@ -4,7 +4,10 @@ import { axiosInstance } from './setupAxios';
 export const oauthSignup = async ({ provider, nickname, code }: OauthSignupParams) => {
   const { data } = await axiosInstance.post(`oauth/sign-up/${provider}`, {
     nickname,
-    redirectUri: `http://localhost:3000/oauth/${provider}`,
+    redirectUri:
+      provider === 'kakao'
+        ? process.env.NEXT_PUBLIC_KAKAO_SIGNUP_REDIRECT_URI
+        : `http://localhost:3000/oauth/${provider}`,
     token: code,
   });
 

--- a/src/fetches/oauthSignup.ts
+++ b/src/fetches/oauthSignup.ts
@@ -4,7 +4,7 @@ import { axiosInstance } from './setupAxios';
 export const oauthSignup = async ({ provider, nickname, code }: OauthSignupParams) => {
   const { data } = await axiosInstance.post(`oauth/sign-up/${provider}`, {
     nickname,
-    redirectUri: 'http://localhost:3000',
+    redirectUri: `http://localhost:3000/oauth/${provider}`,
     token: code,
   });
 


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 카카오 로그인 실패 시 회원 가입 연동 로직 수정

## 📝 작업 내용 설명
- 드롭다운 제작이 완료되어 로그인 시 프로필 영역을 클릭하여 마이 페이지 이동 및 로그아웃이 가능합니다.
- 카카오 로그인 시 로그인이 회원가입 되지 않은 이유(403)으로 실패하면 자동으로 회원가입 연동이 되는데,
로그인 시에 카카오에서 받아온 토큰을 회원가입에서 재사용하면 잘못된 토큰이라는 에러가 발생하는 관계로
새로 다시 토큰을 불러오는 로직 추가

## 💬 리뷰 요구사항(선택)
> 카카오 회원가입 로직 시험 부탁드립니다.

## 🏷️ 연관된 이슈 번호
> #43 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
