### PR TITLE
Fix: ReservationCalendar 컴포넌트에서 mantine 스타일 받을 수 있도록 개선

### DIFF
--- a/src/app/components/@shared/reservationCalendar/ReservationCalendar.tsx
+++ b/src/app/components/@shared/reservationCalendar/ReservationCalendar.tsx
@@ -1,20 +1,24 @@
 import dayjs from 'dayjs';
 import S from './ReservationCalendar.module.scss';
-import { Calendar, CalendarProps } from '@mantine/dates';
+import { Calendar, CalendarProps, CalendarStylesNames } from '@mantine/dates';
 import classNames from 'classnames';
 
-interface ReservationCalendar extends CalendarProps {
+interface ReservationCalendarProps extends CalendarProps {
   selectedDate: Date;
-  availableDates: string[];
   onClickDate: (date: Date) => void;
+  mantineCalendarClassNames?: Record<CalendarStylesNames, string>;
+  availableDates?: string[];
+  availableDatesStyle?: string;
 }
 
 export default function ReservationCalendar({
   selectedDate,
   availableDates,
   onClickDate,
+  mantineCalendarClassNames,
+  availableDatesStyle,
   ...props
-}: ReservationCalendar) {
+}: ReservationCalendarProps) {
   const getDayProps = (date: Date) => {
     const formattedDate = dayjs(date).format('YYYY-MM-DD');
     const isAvailable = availableDates?.includes(formattedDate); // 해당 날짜가 선택 가능한 날짜 배열에 있는 지 검사
@@ -23,8 +27,8 @@ export default function ReservationCalendar({
     return {
       selected: isSelected,
       onClick: () => onClickDate(date),
-      className: classNames({ [S.availableDates]: isAvailable }), // 예약 가능 일에 스타일 부여
-      disabled: !isAvailable, // 예약 가능일이 아니면 선택 불가
+      className: classNames({ [availableDatesStyle || S.availableDates]: isAvailable }), // 예약 가능 일에 스타일 부여
+      disabled: isAvailable !== undefined && !isAvailable, // 예약 가능일이 아니면 선택 불가
     };
   };
 
@@ -33,9 +37,13 @@ export default function ReservationCalendar({
       <Calendar
         date={selectedDate}
         firstDayOfWeek={0}
+        // levelsGroup, day 스타일의 경우, 기본적으로 피그마 스타일대로 구현한 스타일을 따른다.
+        // mantineCalendarClassNames.day에 특정 스타일이 없다면 S.day에서 설정한 스타일이 유지되고,
+        // 같은 스타일 속성이 있을 경우 mantineCalendarClassNames.day가 우선함.
         classNames={{
-          levelsGroup: S.levelsGroup,
-          day: S.day,
+          ...mantineCalendarClassNames,
+          levelsGroup: classNames(S.levelsGroup, mantineCalendarClassNames?.levelsGroup),
+          day: classNames(S.day, mantineCalendarClassNames?.day),
         }}
         {...props}
         getDayProps={getDayProps}


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> ReservationCalendar 컴포넌트에서 mantine 스타일 받을 수 있도록 개선

## 📝 작업 내용 설명
- mantineCalendarClassNames prop으로 mantine에서 제공하는 style api 클래스네임을 사용할 수 있습니다.
- availableDatesStyle prop으로 예약 가능 날짜의 스타일도 따로 부여할 수 있게 했습니다.
- availableDates 배열을 선택적으로 넣도록 하여, 안 넣으면 모든 날짜를 클릭할 수 있게 됩니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 더 필요하거나 수정할 부분이 있다면 알려주세요!

## 🏷️ 연관된 이슈 번호
> [#52 ReservationCalendar에서 Mantine Style 관련 프롭스를 받을 수 있게 개선](#52)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
