### PR TITLE
Hotfix: ReservationCalendar의 mantineCalendarClassNames 프로퍼티의 타입 수정

### DIFF
--- a/src/app/components/@shared/reservationCalendar/ReservationCalendar.tsx
+++ b/src/app/components/@shared/reservationCalendar/ReservationCalendar.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 interface ReservationCalendarProps extends CalendarProps {
   selectedDate: Date;
   onClickDate: (date: Date) => void;
-  mantineCalendarClassNames?: Record<CalendarStylesNames, string>;
+  mantineCalendarClassNames?: Partial<Record<CalendarStylesNames, string>>;
   availableDates?: string[];
   availableDatesStyle?: string;
 }


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> ReservationCalendar의 mantineCalendarClassNames 프로퍼티의 타입 수정

## 📝 작업 내용 설명
기존 mantineCalendarClassNames?: Record<CalendarStylesNames, string>로는
원하는 스타일 클래스만 받을 수 없었기 때문에 mantineCalendarClassNames?: Partial<Record<CalendarStylesNames, string>>; 로 수정

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
