### PR TITLE
Fix: 캘린더 버그 수정

### DIFF
--- a/src/app/components/@shared/reservationCalendar/ReservationCalendar.module.scss
+++ b/src/app/components/@shared/reservationCalendar/ReservationCalendar.module.scss
@@ -37,5 +37,9 @@
       background-color: $green300;
       color: $white;
     }
+
+    &[data-today] {
+      border: 1px solid $gray900;
+    }
   }
 }

--- a/src/app/components/@shared/reservationCalendar/ReservationCalendar.module.scss
+++ b/src/app/components/@shared/reservationCalendar/ReservationCalendar.module.scss
@@ -41,5 +41,12 @@
     &[data-today] {
       border: 1px solid $gray900;
     }
+
+    &[data-disabled] {
+      cursor: not-allowed;
+      &:hover {
+        opacity: 0.2;
+      }
+    }
   }
 }

--- a/src/app/components/reservation/ResponsiveReservation.tsx
+++ b/src/app/components/reservation/ResponsiveReservation.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useReservationStore } from '@/stores/useReservationStore';
 import { ReservationProps } from '@/types/reservation';
 import { useMediaQuery } from '@mantine/hooks';
 import dynamic from 'next/dynamic';
+import { useEffect } from 'react';
 
 // useMediaQuery 특성상, SSR 시에는 undefined, hydration 시에 boolean 값이 부여되는데,
 // 이렇게 되면 모바일 환경에서 접속 시, PC 화면의 컴포넌트가 잠깐 렌더링되었다가 모바일로 바뀌게 된다.
@@ -12,6 +14,17 @@ const Reservation = dynamic(() => import('@/app/components/reservation/Reservati
 
 export default function ResponsiveReservation({ activityId, price }: ReservationProps) {
   const isMobile = useMediaQuery('(max-width: 767px)');
+  const { reset } = useReservationStore(state => state.action);
+
+  useEffect(() => {
+    // zustand의 전역 스토어가 유지됨으로 인해,
+    // 예약 컴포넌트가 언마운트된 이후에도 이전 예약 데이터가 유지되어
+    // 다른 체험의 예약 컴포넌트에 이전 체험 데이터가 영향을 미치는 것을 발견.
+    // 예약 컴포넌트가 언마운트될 때, 예약 데이터를 초기화 하는 작업 실행
+    return () => {
+      reset();
+    };
+  }, []);
 
   return (
     <>

--- a/src/hooks/useReservationSubmit.ts
+++ b/src/hooks/useReservationSubmit.ts
@@ -8,6 +8,7 @@ import { useToggle } from './useToggle';
 // 다른 컴포넌트를 사용해야하므로 중복되는 예약 제출 로직을 모듈화
 export const useReservationSubmit = (activityId: number) => {
   const { headCount, selectedTime } = useReservationStore(state => state.reservation);
+  const { reset } = useReservationStore(state => state.action);
   const [modalMessage, setModalMessage] = useState('');
   const { toggleValue: isModalOpen, toggleDispatch: modalToggle } = useToggle();
   const { mutateAsync } = useReservationMutation(); // 성공, 실패에 따라 다른 modal 창을 열어야 하므로 비동기 처리가 필요함
@@ -17,6 +18,7 @@ export const useReservationSubmit = (activityId: number) => {
       try {
         await mutateAsync({ activityId, headCount, scheduleId: selectedTime.id });
         setModalMessage('예약이 완료되었습니다');
+        reset();
       } catch (error) {
         if (error instanceof AxiosError) {
           if (error.status === 401) {

--- a/src/queries/useAvailableScheduleQuery.ts
+++ b/src/queries/useAvailableScheduleQuery.ts
@@ -11,9 +11,12 @@ export const useAvailableSchedule = ({ activityId, month, year, date }: useAvail
   return useQuery({
     // 날짜를 바꾸는 사이에 다른 사람의 예약이 이루어질 수 있으므로
     // 최대한 사용자가 예약하기를 눌렀을 때, 이미 예약된 일정이 되는 것을 피하기 위해
-    // 선택된 날짜가 바뀌면 새로 서버에서 데이터를 받아오도록 queryKey에 date 추가
+    // 선택된 날짜가 바뀌면 새로 서버에서 데이터를 받아오도록 queryKey에 year, date, month 추가
+    // 선택한 체험이 바뀌면 새로 데이터를 불러오도록 activityId도 추가
     queryKey: [USERS_QUERY_KEY, activityId, year, date, month],
     queryFn: () => getAvailableSchedule({ activityId, month, year }),
+    // 예약 정보 중복을 피하기 위해 사용자가 날짜를 바꿀 때 마다 데이터를 새로 불러오는데,
+    // 이때 컴포넌트의 깜빡임을 없애기 위해, 새로 데이터를 받아오기 전까지 기존 데이터를 유지함
     placeholderData: previousData => previousData,
     select: data => {
       const today = dayjs();

--- a/src/queries/useAvailableScheduleQuery.ts
+++ b/src/queries/useAvailableScheduleQuery.ts
@@ -12,9 +12,9 @@ export const useAvailableSchedule = ({ activityId, month, year, date }: useAvail
     // 날짜를 바꾸는 사이에 다른 사람의 예약이 이루어질 수 있으므로
     // 최대한 사용자가 예약하기를 눌렀을 때, 이미 예약된 일정이 되는 것을 피하기 위해
     // 선택된 날짜가 바뀌면 새로 서버에서 데이터를 받아오도록 queryKey에 date 추가
-    queryKey: [USERS_QUERY_KEY, date, month],
+    queryKey: [USERS_QUERY_KEY, activityId, year, date, month],
     queryFn: () => getAvailableSchedule({ activityId, month, year }),
-    staleTime: 60 * 1000,
+    placeholderData: previousData => previousData,
     select: data => {
       const today = dayjs();
       // 서버에서 받아온 예약 날짜들 중에서 오늘과 그 이후 스케쥴만 뽑아서 전달

--- a/src/stores/useReservationStore.ts
+++ b/src/stores/useReservationStore.ts
@@ -25,5 +25,8 @@ export const useReservationStore = create<ReservationStore>(set => ({
         reservation: { ...prevState.reservation, headCount: Math.max(prevState.reservation.headCount - 1, 1) },
       }));
     },
+    reset: () => {
+      set({ reservation: initialReservation });
+    },
   },
 }));

--- a/src/types/reservation.ts
+++ b/src/types/reservation.ts
@@ -16,6 +16,7 @@ export interface ReservationAction {
   setSelectedTime: (time: Time) => void;
   increaseHeadCount: () => void;
   decreaseHeadCount: () => void;
+  reset: () => void;
 }
 
 export interface ReservationProps {


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 캘린더 버그 수정

## 📝 작업 내용 설명
- 전역 스토어에 의해 컴포넌트가 언마운트 되어도 유지되던 데이터를,
컴포넌트가 언마운트 되거나 예약을 신청한 경우 초기화되도록 수정하였습니다.
- 당일 날짜는 보더 스타일이 적용되도록 해두었습니다.
- 기존 캐싱 때문에 체험이 바뀌어도 AvailableSchedule이 유지되는 것을
staleTime을 없애고, 체험 아이디를 쿼리키에 추가하여 체험이 바뀌면 새로 데이터를 불러오도록 수정하였습니다.
- 선택할 수 없는 날짜의 경우 호버링 시 좀 더 직관적으로 알 수 있도록 스타일을 수정해두었습니다.
- 선택 날짜가 바뀌면 데이터를 새로 불러오기 때문에, 컴포넌트가 깜빡이는 현상이 있었는데,
새로 데이터를 받아올 때까지 기존 데이터를 유지하도록 하여, 해당 현상을 제거하였습니다.

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/98db924a-ebfe-4be3-9df6-ade8d51ec283


## 💬 리뷰 요구사항(선택)
> 더 필요한 수정 사항이나, 발견된 버그가 있다면 알려주세요!

## 🏷️ 연관된 이슈 번호
[#75 예약 캘린더 버그 수정](#75)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
