### PR TITLE
Fix: 마이 페이지 카드 반응형, 모달 버튼 너비 버그 수정

### DIFF
--- a/src/app/(contents)/editactivities/[id]/editActivities.module.scss
+++ b/src/app/(contents)/editactivities/[id]/editActivities.module.scss
@@ -31,12 +31,12 @@
 
 .formContainer {
   flex: 2;
-  @media (max-width: 768px) {
+  @include mobile {
     width: 100%;
   }
 }
 
-@media (max-width: 768px) {
+@include mobile {
   .container {
     flex-direction: column;
     align-items: center;

--- a/src/app/(contents)/mypage/myexperiencemanagement/addactivities/AddActivities.module.scss
+++ b/src/app/(contents)/mypage/myexperiencemanagement/addactivities/AddActivities.module.scss
@@ -31,12 +31,12 @@
 
 .formContainer {
   flex: 2;
-  @media (max-width: 768px) {
+  @include mobile {
     width: 100%;
   }
 }
 
-@media (max-width: 768px) {
+@include mobile {
   .container {
     flex-direction: column;
     align-items: center;

--- a/src/app/(contents)/mypage/myexperiencemanagement/myexperienceManagement.module.scss
+++ b/src/app/(contents)/mypage/myexperiencemanagement/myexperienceManagement.module.scss
@@ -18,7 +18,7 @@
   width: 100%;
   gap: 20px;
 
-  @media (max-width: 910px) {
+  @media (max-width: 768px) {
     flex-direction: column;
     align-items: center;
   }
@@ -28,7 +28,7 @@
   flex: 1;
   width: 100%;
 
-  @media (max-width: 910px) {
+  @media (max-width: 768px) {
     width: 100%;
     margin: 0 auto;
   }
@@ -56,7 +56,7 @@
   margin: 0 auto;
   z-index: 0;
 
-  @media (max-width: 910px) {
+  @media (max-width: 768px) {
     flex: 0 0 auto;
     width: 100%;
     display: flex;

--- a/src/app/(contents)/mypage/myexperiencemanagement/myexperienceManagement.module.scss
+++ b/src/app/(contents)/mypage/myexperiencemanagement/myexperienceManagement.module.scss
@@ -18,7 +18,7 @@
   width: 100%;
   gap: 20px;
 
-  @media (max-width: 768px) {
+  @include mobile {
     flex-direction: column;
     align-items: center;
   }
@@ -28,7 +28,7 @@
   flex: 1;
   width: 100%;
 
-  @media (max-width: 768px) {
+  @include mobile {
     width: 100%;
     margin: 0 auto;
   }
@@ -56,7 +56,7 @@
   margin: 0 auto;
   z-index: 0;
 
-  @media (max-width: 768px) {
+  @include mobile {
     flex: 0 0 auto;
     width: 100%;
     display: flex;

--- a/src/app/(contents)/mypage/myprofile/myprofile.module.scss
+++ b/src/app/(contents)/mypage/myprofile/myprofile.module.scss
@@ -31,12 +31,12 @@
 
 .formContainer {
   flex: 2;
-  @media (max-width: 768px) {
+  @include mobile {
     width: 100%;
   }
 }
 
-@media (max-width: 768px) {
+@include mobile {
   .container {
     flex-direction: column;
     align-items: center;

--- a/src/app/(contents)/myreservations/myreservations.module.scss
+++ b/src/app/(contents)/myreservations/myreservations.module.scss
@@ -32,12 +32,12 @@
 .formContainer {
   max-width: 756px;
   flex: 2;
-  @media (max-width: 768px) {
+  @include mobile {
     width: 100%;
   }
 }
 
-@media (max-width: 768px) {
+@include mobile {
   .container {
     flex-direction: column;
     align-items: center;

--- a/src/app/components/@shared/modal/AlertModal.module.scss
+++ b/src/app/components/@shared/modal/AlertModal.module.scss
@@ -36,7 +36,7 @@
 }
 
 .modalButton {
-  width: 80px;
+  width: 80px !important;
 }
 
 .modalIcon {

--- a/src/app/components/@shared/reservationCalendar/ReservationCalendar.module.scss
+++ b/src/app/components/@shared/reservationCalendar/ReservationCalendar.module.scss
@@ -1,17 +1,14 @@
 @use '@/styles/abstracts/core' as *;
-
 .calendarWrapper {
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-
   .levelsGroup {
     border: 1px solid $gray200;
     border-radius: 8px;
     padding: 10px 27.33px;
   }
-
   .availableDates {
     background-color: $green100;
     color: $green300;
@@ -19,20 +16,16 @@
       background-color: rgba($green300, 0.3);
     }
   }
-
   .day {
     width: 35.71px;
     height: 32px;
     border-radius: 8px;
-
     font-size: 13px;
     font-weight: 600;
     line-height: 17.7px;
-
     &[data-weekend] {
       color: $black;
     }
-
     &[data-selected] {
       background-color: $green300;
       color: $white;

--- a/src/app/components/mypage/MyExperienceManagementCard.module.scss
+++ b/src/app/components/mypage/MyExperienceManagementCard.module.scss
@@ -34,6 +34,7 @@
 
 .title {
   @include textXlBold;
+  font-size: clamp(14px, 2vw, 20px);
   text-decoration: none;
   color: inherit;
   white-space: nowrap;

--- a/src/app/components/mypage/MyExperienceManagementCard.module.scss
+++ b/src/app/components/mypage/MyExperienceManagementCard.module.scss
@@ -1,12 +1,13 @@
 @use '@/styles/abstracts/core' as *;
+
 .card {
   display: flex;
   border-radius: 24px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   margin-bottom: 12px;
   background-color: $white;
-  width: 100%; // 너비를 100%로 설정하여 부모 요소의 너비에 맞추기
-  max-width: 756px; // 최대 너비 설정
+  width: 100%;
+  max-width: 756px;
   height: 204px;
   gap: 10px;
 }
@@ -28,12 +29,18 @@
   margin-top: 10px;
   flex: 1;
   margin-left: 16px;
+  min-width: 0;
 }
 
 .title {
   @include textXlBold;
   text-decoration: none;
   color: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  max-width: 100%;
 }
 
 .rating {

--- a/src/app/components/mypage/ReservationHistoryCard.module.scss
+++ b/src/app/components/mypage/ReservationHistoryCard.module.scss
@@ -59,7 +59,7 @@
 
 .title {
   @include textXlBold;
-  font-size: clamp(18px, 2vw, 20px);
+  font-size: clamp(14px, 2vw, 20px);
   text-decoration: none;
   color: inherit;
   white-space: nowrap;

--- a/src/app/components/mypage/ReservationHistoryCard.module.scss
+++ b/src/app/components/mypage/ReservationHistoryCard.module.scss
@@ -29,6 +29,8 @@
   margin-top: 10px;
   flex: 1;
   margin-left: 16px;
+  margin-right: 20px;
+  min-width: 0;
 }
 
 .status {
@@ -57,31 +59,42 @@
 
 .title {
   @include textXlBold;
+  font-size: clamp(18px, 2vw, 20px);
   text-decoration: none;
   color: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  max-width: 100%;
 }
 
 .details {
   color: $nomadBlack;
+  font-size: clamp(12px, 2vw, 16px);
+  line-height: 1.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
 }
 
 .priceAndButton {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: 50px;
-}
+  padding-top: 50px;
 
-.price {
-  margin-bottom: 25px;
-  color: $gray900;
-  @include textXlSemibold;
-  @media (max-width: 515px) {
-    margin-top: -30px;
+  @media (max-width: 768px) {
+    padding-top: 20px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
   }
 }
 
-.buttonContainer {
-  margin-bottom: 30px;
-  margin-right: 30px;
+.price {
+  color: $gray900;
+  @include textXlSemibold;
 }

--- a/src/styles/abstracts/_colors.scss
+++ b/src/styles/abstracts/_colors.scss
@@ -1,6 +1,6 @@
 $white: #fff;
 $black: #1b1b1b;
-$nomadBlack: #112211;
+$nomadBlack: #221b11;
 $gray900: #4b4b4b;
 $gray800: #79747e;
 $gray700: #a1a1a1;

--- a/src/styles/abstracts/_colors.scss
+++ b/src/styles/abstracts/_colors.scss
@@ -1,6 +1,6 @@
 $white: #fff;
 $black: #1b1b1b;
-$nomadBlack: #221b11;
+$nomadBlack: #112211;
 $gray900: #4b4b4b;
 $gray800: #79747e;
 $gray700: #a1a1a1;


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 
![스크린샷 2024-11-04 165211](https://github.com/user-attachments/assets/8514a0c9-978e-418e-9170-e83921851a78)
![스크린샷 2024-11-04 165223](https://github.com/user-attachments/assets/1194c1f5-c9ea-4b4b-981c-57573e5dc6ee)
![스크린샷 2024-11-04 165255](https://github.com/user-attachments/assets/baaabffe-0928-4518-8124-2533574d7614)
![스크린샷 2024-11-04 165245](https://github.com/user-attachments/assets/5560bdfe-dd3a-4e57-b366-60db017567b4)
예약 내역, 내 체험 관리 페이지의 카드 리스트의 텍스트가 빠져나가는 현상 수정했습니다.
모달의 버튼 너비가 맞지 않는 점 수정했습니다.
## ✅ 체크리스트:
- [X] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [X] 나는 PR 전에 내 코드를 검토했습니다.
- [X] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [X] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
