### PR TITLE
Refactor: 공통 Input 컴포넌트에 기본 input의 props 모두 받을 수 있도록 개선 및 usage 수정

### DIFF
--- a/src/app/components/@shared/input/Input.tsx
+++ b/src/app/components/@shared/input/Input.tsx
@@ -1,45 +1,22 @@
 import classNames from 'classnames';
 import S from './Input.module.scss';
 import { FieldError, FieldErrorsImpl, Merge, UseFormRegisterReturn } from 'react-hook-form';
-import { HTMLInputTypeAttribute } from 'react';
+import { InputHTMLAttributes } from 'react';
 
-interface ValidInputProps {
-  label?: string;
+interface ValidInputProps extends InputHTMLAttributes<HTMLInputElement> {
   htmlFor?: string;
+  label?: string;
   error?: FieldError | Merge<FieldError, FieldErrorsImpl>;
   message?: string | FieldError | Merge<FieldError, FieldErrorsImpl>;
   register?: UseFormRegisterReturn;
-  type?: HTMLInputTypeAttribute;
-  placeholder?: string;
   className?: string;
-  onClick?: (event: React.MouseEvent<HTMLInputElement>) => void;
-  value?: string;
 }
 
-export default function Input({
-  label,
-  htmlFor,
-  error,
-  message,
-  register,
-  type = 'text',
-  placeholder = '',
-  className,
-  onClick,
-  value,
-}: ValidInputProps) {
+export default function Input({ htmlFor, label, error, message, register, className, ...inputProps }: ValidInputProps) {
   return (
     <div className={classNames(S.inputWrapper, className)}>
       {label && <label htmlFor={htmlFor}>{label}</label>}
-      <input
-        id={htmlFor}
-        type={type}
-        className={classNames({ [S.error]: error })}
-        placeholder={placeholder}
-        {...register}
-        onClick={onClick}
-        value={value}
-      />
+      <input id={htmlFor} className={classNames({ [S.error]: error })} {...register} {...inputProps} />
       {message && <p className={S.message}>{message.toString()}</p>}
     </div>
   );

--- a/src/usages/Input.usage.md
+++ b/src/usages/Input.usage.md
@@ -20,11 +20,8 @@
 - error(FieldError | Merge<FieldError, FieldErrorsImpl>)?: register에 있는 입력 필드의 error 객체입니다.
 - message(string | FieldError | Merge<FieldError, FieldErrorsImpl>)? register에 있는 입력 필드의 massage 객체입니다.
 - register(UseFormRegisterReturn)?: useValidForm 훅에서 반환되는 register 객체입니다.
-- type(HTMLInputTypeAttribute, default: 'text')?: input 타입입니다.
-- placeholder(string)?: 플레이스홀더 텍스트입니다.
 - className(string)?: input을 감싸고 있는 div에 들어갈 className으로, 커스텀 스타일이 가능합니다.
-- value?(string): 특정 value가 고정으로 들어가야 하는 경우 사용할 수 있습니다.
-- onClick?(event: React.MouseEvent<HTMLInputElement>)=>void: button의 onClick 이벤트가 필요한 경우 사용할 수 있습니다.
+- ...inputProps: 기본 input 요소에서 제공하는 모든 프로퍼티들도 원하실 경우 추가해서 사용하실 수 있습니다.
 
 # useValidForm Custom Hook
 


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 공통 Input 컴포넌트에 기본 input의 props 모두 받을 수 있도록 개선 및 usage 수정

## 📝 작업 내용 설명
- 공용 Input 컴폰넌트에서 기본 input 엘리먼트의 props를 전부 받을 수 있도록 리팩토링해두었습니다.
- value, onClick, onChange 등 모두 사용부에서 임의로 적용 가능합니다.
- 이에 따라 사용법 파일도 수정해두었습니다.

## 💬 리뷰 요구사항(선택)
> 혹시나 버그가 나거나 사용 시에 문제가 있다면 알려주세요

## 🏷️ 연관된 이슈 번호
> [#85 공통 Input 컴포넌트 props 관련 리팩토링](#85)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
