### PR TITLE
Fix: 리팩토링 도중 잘못된 로직 수정 및 헤더 로고 크기 조정

### DIFF
--- a/src/app/components/@shared/header/Header.module.scss
+++ b/src/app/components/@shared/header/Header.module.scss
@@ -26,26 +26,26 @@
   width: 100%;
   max-width: 1200px;
   margin: 0 24px;
-}
 
-.notLoggedInContainer {
-  display: flex;
-  gap: 25px;
-  @include textMdMedium;
-
-  a {
-    color: $black;
-    text-decoration: none;
-  }
-}
-
-@include mobile {
   .headerLogo {
-    img {
-      @include mobile {
-        width: 140px;
-        height: auto;
+    display: flex; // 수직 중앙 정렬
+    @include mobile {
+      img {
+        @include mobile {
+          width: 140px;
+        }
       }
+    }
+  }
+
+  .notLoggedInContainer {
+    display: flex;
+    gap: 25px;
+    @include textMdMedium;
+
+    a {
+      color: $black;
+      text-decoration: none;
     }
   }
 }

--- a/src/app/components/@shared/header/Header.tsx
+++ b/src/app/components/@shared/header/Header.tsx
@@ -31,9 +31,7 @@ export default function Header() {
       // 새로 유저 정보를 받아왔으므로 전역 상태 업데이트
       setUser({ user });
     }
-    if (!user || isError) {
-      // 쿠키에 accessToken이 삭제되는 등의 이유로 accessToken이 없다면 useUserQuery가 enabled 속성에 의해
-      // 작동하지 않으므로 이때에도 로그아웃이 필요.
+    if (isError) {
       // 네트워크 에러, 리프레시 토큰 만료 등의 이유로, 유저 데이터를 받아오지 못한다면 로그아웃
       logout();
     }


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 이번 PR에서 작업한 내용을 요약해주세요(이미지 첨부 가능)

## 📝 작업 내용 설명
- useQuery가 suspense 처리되지 않아 기본적으로 user를 undefined로 반환하고
데이터를 받아와서야 값을 업데이트하기 때문에 로그아웃 조건에 user가 들어있으면 안되는 것을 확인하여 수정해두었습니다.
- 헤더 로고가 약간 위로 치우쳐 있어 수직 중앙 정렬 해두었습니다.

## 🏷️ 연관된 이슈 번호
> [#83 헤더 자동 로그인 및 유저 정보 업데이트 코드 주석 추가] (#83)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
