### PR TITLE
Fix: 드롭다운 외부 클릭 시 닫히지 않던 버그 수정

### DIFF
--- a/src/app/components/@shared/dropdown/Dropdown.module.scss
+++ b/src/app/components/@shared/dropdown/Dropdown.module.scss
@@ -70,6 +70,11 @@
   white-space: nowrap;
 }
 
+.selectDropdownInfo {
+  @extend .DropdownInfo;
+  background-color: $gray300;
+}
+
 .categoryDropdownInfo {
   top: 60px;
   position: absolute;
@@ -82,6 +87,7 @@
   border: 1px solid $gray300;
   background-color: $white;
   width: 100%;
+  box-shadow: 0px 3px 9px rgba(0, 0, 0, 0.5);
 }
 
 .kebabDropdownInfo {
@@ -98,6 +104,7 @@
   background-color: $white;
   min-width: 160px;
   width: 100%;
+  box-shadow: 0px 3px 9px rgba(0, 0, 0, 0.5);
 }
 
 .hideDropdownInfo {
@@ -114,4 +121,5 @@
   background-color: $white;
   min-width: 160px;
   width: 100%;
+  box-shadow: 0px 3px 9px rgba(0, 0, 0, 0.5);
 }

--- a/src/app/components/@shared/dropdown/Dropdown.module.scss
+++ b/src/app/components/@shared/dropdown/Dropdown.module.scss
@@ -4,6 +4,7 @@
   display: inline-flex;
   flex-direction: column;
   position: relative;
+  width: 100%;
 }
 
 .KebabIconWrapper {
@@ -20,7 +21,14 @@
   padding: 16px 20px;
 }
 
-.categoryValue {
+.categoryWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  border: 1px solid $gray800;
+  border-radius: 6px;
+  padding: 16px 20px;
 }
 
 .categoryWrapper {
@@ -33,20 +41,6 @@
   padding: 16px 20px;
 }
 
-.categoryValue {
-}
-
-.categoryWrapper {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  border: 1px solid $gray800;
-  border-radius: 6px;
-  padding: 16px 20px;
-}
-.categoryValue {
-}
 .dropdownButton {
   display: flex;
   align-items: center;

--- a/src/app/components/@shared/dropdown/Dropdown.tsx
+++ b/src/app/components/@shared/dropdown/Dropdown.tsx
@@ -5,6 +5,9 @@ import dropdownArrow from '@/images/dropdown-arrow.svg';
 import kebabIcon from '@/images/kebab-icon.svg';
 import dropdownThinArrow from '@/images/dropdown-thin-arrow.svg';
 import Image from 'next/image';
+import BackDrop from '../backdrop/BackDrop';
+import { useToggle } from '@/hooks/useToggle';
+import { useEffect } from 'react';
 
 interface DropdownProps {
   data: string[];
@@ -53,28 +56,31 @@ export default function Dropdown({
         )}
 
         {isDropdownToggle && (
-          <div
-            className={
-              type === 'category'
-                ? S.categoryDropdownInfo
-                : type === 'kebab'
-                  ? S.kebabDropdownInfo
-                  : type === 'hide'
-                    ? S.hideDropdownInfo
-                    : S.categoryDropdownInfo // 나머지 타입에 대한 클래스
-            }
-          >
-            {data.map((item, index) => (
-              <div
-                className={S.DropdownInfo}
-                key={`${item}+${index}`}
-                onClick={() => handleSelectValue(item, index)}
-                style={{ borderBottom: index === data.length - 1 ? 'none' : '1px solid #gray300' }}
-              >
-                {item}
-              </div>
-            ))}
-          </div>
+          <>
+            <BackDrop onClose={toggleDropdown} />
+            <div
+              className={
+                type === 'category'
+                  ? S.categoryDropdownInfo
+                  : type === 'kebab'
+                    ? S.kebabDropdownInfo
+                    : type === 'hide'
+                      ? S.hideDropdownInfo
+                      : S.categoryDropdownInfo // 나머지 타입에 대한 클래스
+              }
+            >
+              {data.map((item, index) => (
+                <div
+                  className={`${S.DropdownInfo} ${selectedValue === item ? S.selectDropdownInfo : ''}`}
+                  key={`${item}+${index}`}
+                  onClick={() => handleSelectValue(item, index)}
+                  style={{ borderBottom: index === data.length - 1 ? 'none' : '1px solid #gray300' }}
+                >
+                  {item}
+                </div>
+              ))}
+            </div>
+          </>
         )}
       </div>
     </>

--- a/src/app/components/myReservations/Reservations/Reservations.tsx
+++ b/src/app/components/myReservations/Reservations/Reservations.tsx
@@ -74,6 +74,7 @@ export default function Reservations() {
       }
       const selectedActivityId = Mydata.activities[0].id;
       setActivityId(selectedActivityId);
+      onDropdownChange(Mydata.activities[0].title);
       fetchReservationData({ activityId: selectedActivityId, year, month });
     }
   }, [Mydata, selectedIndex, activityId, selectedDate]);


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 드롭다운 외부 클릭 시 닫힘 기능 추가, 선택 항목 강조 처리, 선택항목 주변 쉐도우 추가

## 📝 작업 내용 설명
> 드롭다운 외부 클릭 시 닫힘 기능 추가, 선택 항목 강조 처리, 선택항목 주변 쉐도우 추가

## 📷 스크린샷
![드롭다운 수정](https://github.com/user-attachments/assets/b24359fb-5fcd-4307-a3d9-895e503ecad6)

## 🏷️ 연관된 이슈 번호
> #80 

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
