### PR TITLE
#94 Fix: oauthSignup함수의 redirectUri를 환경 변수로 수정

### DIFF
--- a/src/fetches/oauthSignup.ts
+++ b/src/fetches/oauthSignup.ts
@@ -7,7 +7,7 @@ export const oauthSignup = async ({ provider, nickname, code }: OauthSignupParam
     redirectUri:
       provider === 'kakao'
         ? process.env.NEXT_PUBLIC_KAKAO_SIGNUP_REDIRECT_URI
-        : `http://localhost:3000/oauth/${provider}`,
+        : process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI,
     token: code,
   });
 


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> oauthSignup함수의 redirectUri를 환경 변수로 수정

## 📝 작업 내용 설명
- oauthSignup 함수에 localhost 주소가 하드코딩 되어 있는 부분을 발견하여, redirectUri를 환경 변수로 수정

## 🏷️ 연관된 이슈 번호
> [#94 oauthSignup 함수에 localhost 주소가 하드코딩 되어 있는 부분을 발견](#94)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
