### PR TITLE
Fix: 애니메이션 추가, 사이드메뉴 버튼 범위 수정

### DIFF
--- a/src/app/components/mypage/MyExperienceManagementList.module.scss
+++ b/src/app/components/mypage/MyExperienceManagementList.module.scss
@@ -1,8 +1,27 @@
 @use '@/styles/abstracts/core' as *;
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .list {
   display: flex;
   flex-direction: column;
 }
+
+.cardItem {
+  opacity: 0;
+  transform: translateY(1rem);
+  animation: slideIn 0.5s ease-out forwards;
+}
+
 .emptyState {
   display: flex;
   flex-direction: column;

--- a/src/app/components/mypage/MyExperienceManagementList.tsx
+++ b/src/app/components/mypage/MyExperienceManagementList.tsx
@@ -20,7 +20,6 @@ function MyExperienceManagementList() {
     cursorId: null,
     size: 10,
   });
-
   const { refetch: fetchNextPage } = useMyActivitiesQuery({
     cursorId,
     size: 10,
@@ -106,8 +105,16 @@ function MyExperienceManagementList() {
 
   return (
     <div className={S.list}>
-      {activities.map(activity => (
-        <MyExperienceManagementCard key={activity.id} experience={activity} />
+      {activities.map((activity, index) => (
+        <div
+          key={activity.id}
+          className={S.cardItem}
+          style={{
+            animationDelay: `${index * 100}ms`,
+          }}
+        >
+          <MyExperienceManagementCard experience={activity} />
+        </div>
       ))}
       <div ref={observerRef} className={S.loading}>
         {isFetchingNextPage && <Loader />}

--- a/src/app/components/mypage/ReservationHistoryCardList.module.scss
+++ b/src/app/components/mypage/ReservationHistoryCardList.module.scss
@@ -1,5 +1,20 @@
 @use '@/styles/abstracts/core' as *;
 
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.container {
+  width: 100%;
+}
+
 .header {
   display: flex;
   justify-content: space-between;
@@ -16,20 +31,10 @@
   flex-direction: column;
 }
 
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 16px;
-}
-
-.title {
-  @include text3XlBold;
-}
-
-.list {
-  display: flex;
-  flex-direction: column;
+.cardItem {
+  opacity: 0;
+  transform: translateY(1rem);
+  animation: slideIn 0.5s ease-out forwards;
 }
 
 .text {
@@ -57,6 +62,7 @@
   @include textLgRegular;
   color: $gray600;
 }
+
 .dropdownWrapper {
   width: 150px;
 }

--- a/src/app/components/mypage/ReservationHistoryCardList.tsx
+++ b/src/app/components/mypage/ReservationHistoryCardList.tsx
@@ -140,13 +140,20 @@ function ReservationHistoryCardList() {
       <div className={S.list}>
         {displayedReservations.length > 0 ? (
           <>
-            {displayedReservations.map(reservation => (
-              <ReservationHistoryCard
+            {displayedReservations.map((reservation, index) => (
+              <div
                 key={reservation.id}
-                reservation={reservation}
-                onCancelSuccess={handleReviewSubmitted}
-                onReviewSubmitted={handleReviewSubmitted}
-              />
+                className={S.cardItem}
+                style={{
+                  animationDelay: `${index * 100}ms`,
+                }}
+              >
+                <ReservationHistoryCard
+                  reservation={reservation}
+                  onCancelSuccess={handleReviewSubmitted}
+                  onReviewSubmitted={handleReviewSubmitted}
+                />
+              </div>
             ))}
             {hasMore && (
               <div ref={loadingRef} className={S.loadingContainer}>

--- a/src/app/components/mypage/SideMenu.module.scss
+++ b/src/app/components/mypage/SideMenu.module.scss
@@ -23,6 +23,7 @@
       border-radius: 50%;
       overflow: hidden;
       margin: 20px 0;
+      cursor: pointer;
 
       .profileImage {
         position: absolute;
@@ -37,6 +38,7 @@
       display: flex;
       justify-content: center;
       align-items: center;
+      cursor: pointer;
     }
   }
 
@@ -56,6 +58,7 @@
           background-color 0.3s,
           color 0.3s;
         color: $gray800;
+        cursor: pointer;
 
         &:hover {
           background-color: $gray200;
@@ -74,6 +77,10 @@
         a {
           color: inherit;
           text-decoration: none;
+          display: flex;
+          align-items: center;
+          width: 100%;
+          height: 100%;
         }
       }
     }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/site.webmanifest" />
+        <link rel="preload" href="/images/sidemenuIcon/myprofile-Icon.svg" as="image" type="image/svg+xml" />
+        <link rel="preload" href="/images/sidemenuIcon/reservationhistory-Icon.svg" as="image" type="image/svg+xml" />
+        <link
+          rel="preload"
+          href="/images/sidemenuIcon/myexperiencemanagement-Icon.svg"
+          as="image"
+          type="image/svg+xml"
+        />
+        <link rel="preload" href="/images/sidemenuIcon/reservationstatus-Icon.svg" as="image" type="image/svg+xml" />
+        <link rel="preload" href="/images/sidemenuIcon/profile-button-icon.svg" as="image" type="image/svg+xml" />
       </head>
       <body>
         <Providers>


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 
![Honeycam 2024-11-13 16-03-32](https://github.com/user-attachments/assets/33489973-cc8a-4f0d-9fc4-dab475974e48)


## 📝 작업 내용 설명
> 카드 리스트에 애니메이션을 추가했습니다.
> 사이드 메뉴 프로필 변경 버튼의 커서를 손모양으로 변경했습니다
> 사이드 메뉴의 버튼 범위를 수정했습니다.

## ✅ 체크리스트:
- [X] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [X] 나는 PR 전에 내 코드를 검토했습니다.
- [X] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [X] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
